### PR TITLE
Fixed leptonica requirement

### DIFF
--- a/release/install_requires_related2opencv.sh
+++ b/release/install_requires_related2opencv.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 sudo apt-get install \
-leptonica \
+liblept5 \
 libaec0 \
 libatlas3-base \
 libatomic1 \


### PR DESCRIPTION
As of April 2019, leptonica is not a valid package on Raspberry Pi 3 B+. I believe the correct library is instead liblept5, as the leptonica-progs package requires only liblept5.